### PR TITLE
Fix/frf 197 contact forms fieldset and legend

### DIFF
--- a/src/__tests__/Feedback.spec.tsx
+++ b/src/__tests__/Feedback.spec.tsx
@@ -49,7 +49,7 @@ test('Initial form state', async () => {
 
   expect(getByText('All fields are required unless marked as optional.')).toBeInTheDocument()
 
-  expect(screen.getAllByRole('group')).toHaveLength(3)
+  expect(screen.getAllByRole('group')).toHaveLength(2)
 
   // How helpful was the Find, Recruit and Follow-up (FRF) website?
   expect(

--- a/src/pages/contact-data-service-provider/[slug]/index.tsx
+++ b/src/pages/contact-data-service-provider/[slug]/index.tsx
@@ -6,7 +6,7 @@ import { ReactElement, useCallback } from 'react'
 import { FieldError, useForm } from 'react-hook-form'
 
 import { Container } from '@/components/Container/Container'
-import { ErrorSummary, Fieldset, Form, HoneyPot, Textarea, TextInput } from '@/components/Form'
+import { ErrorSummary, Form, HoneyPot, Textarea, TextInput } from '@/components/Form'
 import { RootLayout } from '@/components/Layout/RootLayout'
 import { TEXTAREA_MAX_CHARACTERS } from '@/constants/forms'
 import { useFormErrorHydration } from '@/hooks/useFormErrorHydration'
@@ -73,7 +73,7 @@ export default function ContactDataServiceProvider({ name, query }: ContactDataS
             >
               <ErrorSummary errors={errors} />
               <HoneyPot {...register('workEmailAddress')} />
-              <Fieldset>
+              <div>
                 <TextInput
                   label="Full name"
                   errors={errors}
@@ -115,7 +115,7 @@ export default function ContactDataServiceProvider({ name, query }: ContactDataS
                   defaultValue={defaultValues?.studyDescription}
                   {...register('studyDescription')}
                 />
-              </Fieldset>
+              </div>
 
               <p>We will email you a copy of this form for your records</p>
 

--- a/src/pages/contact-frf-team/index.tsx
+++ b/src/pages/contact-frf-team/index.tsx
@@ -6,7 +6,7 @@ import { ReactElement, useCallback } from 'react'
 import { FieldError, useForm } from 'react-hook-form'
 
 import { Container } from '@/components/Container/Container'
-import { ErrorSummary, Fieldset, Form, HoneyPot, Textarea, TextInput } from '@/components/Form'
+import { ErrorSummary, Form, HoneyPot, Textarea, TextInput } from '@/components/Form'
 import { RootLayout } from '@/components/Layout/RootLayout'
 import { TEXTAREA_MAX_CHARACTERS } from '@/constants/forms'
 import { useFormErrorHydration } from '@/hooks/useFormErrorHydration'
@@ -72,7 +72,7 @@ export default function ContactFrfTeam({ query }: ContactFrfTeamProps) {
             >
               <ErrorSummary errors={errors} />
               <HoneyPot {...register('workEmailAddress')} />
-              <Fieldset>
+              <div>
                 <TextInput
                   label="Full name"
                   errors={errors}
@@ -113,7 +113,7 @@ export default function ContactFrfTeam({ query }: ContactFrfTeamProps) {
                   defaultValue={defaultValues?.details}
                   {...register('details')}
                 />
-              </Fieldset>
+              </div>
 
               <p>We will email you a copy of this form for your records</p>
 

--- a/src/pages/feedback/index.tsx
+++ b/src/pages/feedback/index.tsx
@@ -66,7 +66,7 @@ export default function Feedback({ query }: FeedbackProps) {
             >
               <ErrorSummary errors={errors} />
               <HoneyPot {...register('workEmailAddress')} />
-              <Fieldset>
+              <div>
                 <RadioGroup
                   label="How helpful was the Find, Recruit and Follow-up (FRF) website?"
                   errors={errors}
@@ -86,7 +86,7 @@ export default function Feedback({ query }: FeedbackProps) {
                   defaultValue={defaultValues?.suggestions}
                   {...register('suggestions')}
                 />
-              </Fieldset>
+              </div>
 
               <Fieldset
                 className="govuk-!-margin-top-7"


### PR DESCRIPTION
Fieldset and legend to be used for grouping a question with a range of answers, and grouping questions together that can be described by a legend. This FRF form is a good example: https://findrecruitandfollowup.nihr.ac.uk/contact-research-support

See other examples on https://www.gov.uk/contact/govuk and https://www.nhs.uk/contact-us/nhs-app-contact-us/tell-us-what-you-need-help-with