### PR TITLE
resolve close filters locator

### DIFF
--- a/qa/pages/ProvidersPage.ts
+++ b/qa/pages/ProvidersPage.ts
@@ -168,9 +168,7 @@ export default class ProvidersPage {
     this.dspFilterMobileBtnClose = page.locator(
       'a[href="#show-filters"][class=" govuk-button govuk-button--secondary w-full text-center md:hidden"]'
     )
-    this.dspFilterMobileIconClose = page.locator(
-      'a[href="#show-filters"][aria-label="Collapse search criteria filters"]'
-    )
+    this.dspFilterMobileIconClose = page.locator('a[data-testid="closeFiltersIcon"]')
     this.dspFilterPanel = page.locator('div[id="filters"]')
     this.dspFilterServiceTitle = page.locator('details span[class="govuk-body m-0"]', { hasText: 'Type of service' })
     this.dspFilterServiceSection = page.locator('legend[class="govuk-visually-hidden"]', {

--- a/qa/pages/ProvidersPage.ts
+++ b/qa/pages/ProvidersPage.ts
@@ -168,7 +168,9 @@ export default class ProvidersPage {
     this.dspFilterMobileBtnClose = page.locator(
       'a[href="#show-filters"][class=" govuk-button govuk-button--secondary w-full text-center md:hidden"]'
     )
-    this.dspFilterMobileIconClose = page.locator('a[href="#show-filters"][aria-label="Close search criteria filters"]')
+    this.dspFilterMobileIconClose = page.locator(
+      'a[href="#show-filters"][aria-label="Collapse search criteria filters"]'
+    )
     this.dspFilterPanel = page.locator('div[id="filters"]')
     this.dspFilterServiceTitle = page.locator('details span[class="govuk-body m-0"]', { hasText: 'Type of service' })
     this.dspFilterServiceSection = page.locator('legend[class="govuk-visually-hidden"]', {

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -74,8 +74,9 @@ export function Filters({
         <a
           href="#show-filters"
           className="text-white focus:text-black md:hidden"
-          aria-label="Collapse search criteria filters"
+          aria-label="Close search criteria filters"
           onClick={onRequestClose}
+          data-testid="closeFiltersIcon"
         >
           <Cross className="text-[2em]" />
         </a>

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -74,7 +74,7 @@ export function Filters({
         <a
           href="#show-filters"
           className="text-white focus:text-black md:hidden"
-          aria-label="Close search criteria filters"
+          aria-label="Collapse search criteria filters"
           onClick={onRequestClose}
         >
           <Cross className="text-[2em]" />


### PR DESCRIPTION
the new aria-label was causing a locator test to resolve to two elements. Added a data-testid attribute to better identify the close from the close button.