### PR TITLE
Fix/crncc 1689 prb 0040218 frf website formatting issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ next-env.d.ts
 /playwright/.cache/
 qa/test-results/
 qa/test-report/
+.idea

--- a/README.md
+++ b/README.md
@@ -49,3 +49,18 @@ To generate database migrations + rebuild the local Prisma client run: `npm run 
 ## Emails
 
 Sending email notifications requires adding AWS credentials to `.env.local`. These are temporary credentials with a 1 hour expiry. From the AWS account page, click **Command line or programmatic access** and copy over the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` values.
+
+## Content Migration
+
+If this is the first time you are migrating content, you will need to install the CLI tool. If you have already installed the CLI tool, you can skip to step 3.
+
+1. Install the CLI tool globally using npm `npm install -g contentful-cli`
+2. Login to the CLI tool using `contentful login`
+3. Set the default space using `contentful space use --space-id <SPACE_ID>`
+4. Export the content from the source space using `contentful space export --space-id <SPACE_ID> --environment-id <ENVIRONMENT_ID>`
+5. Import the content into the destination space using `contentful space import --space-id <SPACE_ID> --environment-id <ENVIRONMENT_ID> --content-file <FILE_NAME>`
+
+### Optional
+
+1. If you want to delete the content from the source space, you can use `npm install -g contentful-clean-space` to install the CLI tool
+2. Then run `contentful-clean-space --space-id <SPACE_ID> --environment-id <ENVIRONMENT_ID>  --accesstoken <CONTENTFUL_MANAGEMENT_ACCESS_TOKEN>` to delete all content from the source space

--- a/src/pages/providers/[...slug].tsx
+++ b/src/pages/providers/[...slug].tsx
@@ -25,7 +25,6 @@ import {
   TypesOfData,
 } from '@/components/Provider'
 import { RichTextRenderer } from '@/components/Renderers/RichTextRenderer/RichTextRenderer'
-import { TextRenderer } from '@/components/Renderers/TextRenderer/TextRenderer'
 import { Video } from '@/components/Video/Video'
 import { contentfulService } from '@/lib/contentful'
 import { getStaticPropsRevalidateValue } from '@/utils'
@@ -137,14 +136,14 @@ export default function ServiceProvider({ fields, createdAt, updatedAt }: Servic
                 {/* Geographical and population coverage  */}
                 {fields.geographicAndPopulationCoverage && (
                   <Section heading="Geographical and population coverage" icon={<GlobeIcon />}>
-                    <TextRenderer>{fields.geographicAndPopulationCoverage}</TextRenderer>
+                    <RichTextRenderer>{fields.geographicAndPopulationCoverage}</RichTextRenderer>
                   </Section>
                 )}
 
                 {/* Information governance */}
                 {fields.informationGovernance && (
                   <Section heading="Information governance" icon={<GovernanceIcon />}>
-                    <TextRenderer>{fields.informationGovernance}</TextRenderer>
+                    <RichTextRenderer>{fields.informationGovernance}</RichTextRenderer>
                   </Section>
                 )}
 

--- a/src/utils/serviceTypes.utils.tsx
+++ b/src/utils/serviceTypes.utils.tsx
@@ -1,6 +1,5 @@
 import { Details } from '@/components/Details/Details'
 import { RichTextRenderer } from '@/components/Renderers/RichTextRenderer/RichTextRenderer'
-import { TextRenderer } from '@/components/Renderers/TextRenderer/TextRenderer'
 import { ServiceType } from '@/constants'
 import { ServiceProviderProps } from '@/pages/providers/[...slug]'
 
@@ -105,19 +104,19 @@ export const formatServiceTypeBlock = (serviceType: ServiceType, costs: Costs, c
 
   return (
     <>
-      {fields.description && <TextRenderer>{fields.description}</TextRenderer>}
+      {fields.description && <RichTextRenderer>{fields.description}</RichTextRenderer>}
 
       {fields.howTheServiceWorks && (
         <>
           <p className="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-margin-top-6">How the service works:</p>
-          <TextRenderer>{fields.howTheServiceWorks}</TextRenderer>
+          <RichTextRenderer>{fields.howTheServiceWorks}</RichTextRenderer>
         </>
       )}
 
       {fields.expectedTimelines && (
         <>
           <p className="govuk-heading-s govuk-!-margin-bottom-2 govuk-!-margin-top-6">Expected timelines:</p>
-          <TextRenderer>{fields.expectedTimelines}</TextRenderer>
+          <RichTextRenderer>{fields.expectedTimelines}</RichTextRenderer>
         </>
       )}
 
@@ -145,7 +144,7 @@ export const formatServiceTypeBlock = (serviceType: ServiceType, costs: Costs, c
             item?.fields.heading &&
             item.fields.text && (
               <Details key={i} heading={item.fields.heading}>
-                <TextRenderer>{item.fields.text}</TextRenderer>
+                <RichTextRenderer>{item.fields.text}</RichTextRenderer>
               </Details>
             )
         )}


### PR DESCRIPTION
There appears to be a <TextRenderer> component wrapping 6 elements of the incoming content.  These are:
howTheServiceWorks
description
expectedTimelines
text
geographicAndPopulationCoverage
informationGovernance

Having looked through the contentful data models these are all presented as rich text but they will only display as rich text for the user if they are wrapped in the <RichTextRenderer> component