### PR TITLE
CRNCC 2532, deployment fixes.

### DIFF
--- a/.github/workflows/frf-web-deploy-all-env.yml
+++ b/.github/workflows/frf-web-deploy-all-env.yml
@@ -287,7 +287,7 @@ jobs:
           path: qa/test-report/
           retention-days: 3
       - name: 'Download HTML Report Artifact'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@4.3.0
         id: download
         if: github.event.inputs.publish-report != 'false' && always()
       - name: Publish to GH Pages

--- a/.github/workflows/frf-web-deploy-all-env.yml
+++ b/.github/workflows/frf-web-deploy-all-env.yml
@@ -288,7 +288,6 @@ jobs:
           retention-days: 3
       - name: 'Download HTML Report Artifact'
         uses: actions/download-artifact@4.3.0
-        uses: actions/download-artifact@v4
         id: download
         if: github.event.inputs.publish-report != 'false' && always()
       - name: Publish to GH Pages

--- a/.github/workflows/frf-web-deploy-all-env.yml
+++ b/.github/workflows/frf-web-deploy-all-env.yml
@@ -280,7 +280,7 @@ jobs:
         run: |
           aws ec2 revoke-security-group-ingress --group-id ${{ secrets.LB_SG_TEST }} --ip-permissions '[{"IpProtocol": "tcp", "FromPort": 443, "ToPort": 443, "IpRanges": [{"CidrIp": "${{ steps.publicip.outputs.ip }}/32", "Description": "GitHub runner IP for FRF automation test run"}]}]'
       - name: Upload HTML Report as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@4.6.2
         if: always()
         with:
           name: test-report

--- a/.github/workflows/frf-web-deploy-all-env.yml
+++ b/.github/workflows/frf-web-deploy-all-env.yml
@@ -247,7 +247,7 @@ jobs:
     environment: TEST
     name: 'Run E2E Tests'
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/frf-web-deploy-all-env.yml
+++ b/.github/workflows/frf-web-deploy-all-env.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: 'Build'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-node
@@ -56,7 +56,7 @@ jobs:
     needs: [build]
     environment: DEV
     name: 'Deploy Dev'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -151,7 +151,7 @@ jobs:
     needs: deploy-dev
     environment: TEST
     name: 'Deploy Test'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -317,7 +317,7 @@ jobs:
     needs: e2e-test
     environment: UAT
     name: 'Deploy Uat'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -412,7 +412,7 @@ jobs:
     needs: deploy-uat
     environment: OAT
     name: 'Deploy Oat'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3
@@ -507,7 +507,7 @@ jobs:
     needs: deploy-oat
     environment: PROD
     name: 'Deploy Prod'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS base
+FROM node:18-alpin3.20  AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/qa/pages/CommonItemsPage.ts
+++ b/qa/pages/CommonItemsPage.ts
@@ -255,7 +255,7 @@ export default class CommonItemsPage {
     const cookieList = await this.getCookies()
     const ytCookiesArray = getDomainSpecificCookieList(cookieList, '.youtube.com')
     if (applied) {
-      expect(ytCookiesArray.length).toEqual(3)
+      expect(ytCookiesArray.length).toEqual(4)
       expect(ytCookiesArray.some((cookie) => cookie.name == 'YSC')).toBeTruthy()
       expect(ytCookiesArray.some((cookie) => cookie.name == 'VISITOR_INFO1_LIVE')).toBeTruthy()
     } else {
@@ -306,7 +306,6 @@ export default class CommonItemsPage {
 
   async assertOnNihrHomePage() {
     await expect(this.page).toHaveURL('https://www.nihr.ac.uk/')
-    expect(await this.page.title()).toEqual('Homepage | NIHR')
   }
 
   async assertShawTrustNavigation() {


### PR DESCRIPTION
updated e2e tests,
removed page title name from nihr homepage, left url check as its unlikely to change unexpectedly.
updated youtube cookie count to reflect current youtube cookies.

pinned alpine docker image version,
current version of prisma is not compatible with openssl 3, updating prisma will require other packages to be updated alongside it and probable code changes. 

pinned ubuntu version in github actions to avoid issues seen in rts. 